### PR TITLE
Add constraint and values fields to sla-violation resource

### DIFF
--- a/_demo/README.md
+++ b/_demo/README.md
@@ -410,7 +410,9 @@ cat >>slaViolation.json <<EOF
 {
     "guarantee" : "TestGuarantee",
     "datetime" : "2018-04-11T10:39:51.527008088Z",
-    "agreement_id" : "agreement/4e529393-f659-44d6-9c8b-b0589132599b"
+    "agreement_id" : "agreement/4e529393-f659-44d6-9c8b-b0589132599b",
+    "constraint": "var1 < 100 and var2 > 100",
+    "values": { "var1": 101, "var2": 100 }
 }
 EOF
 

--- a/_demo/README.md
+++ b/_demo/README.md
@@ -410,7 +410,7 @@ cat >>slaViolation.json <<EOF
 {
     "guarantee" : "TestGuarantee",
     "datetime" : "2018-04-11T10:39:51.527008088Z",
-    "agreement_id" : "agreement/4e529393-f659-44d6-9c8b-b0589132599b",
+    "agreement_id" : {"href": "agreement/4e529393-f659-44d6-9c8b-b0589132599b"},
     "constraint": "var1 < 100 and var2 > 100",
     "values": { "var1": 101, "var2": 100 }
 }

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/sla_violation.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/sla_violation.cljc
@@ -9,11 +9,16 @@
 ;   "agreement_id": URI
 ;   "guarantee": string
 ;   "datetime": datetime
+;   "constraint": string
+;   "values": map<string,object>
 ; }
 
 (s/def :cimi.sla-violation/agreement_id :cimi.common/resource-link)
 (s/def :cimi.sla-violation/guarantee string?)
 (s/def :cimi.sla-violation/datetime :cimi.core/timestamp)
+(s/def :cimi.sla-violation/constraint string?)
+(s/def :cimi.sla-violation/values (su/constrained-map keyword? any?))
+
 
 (s/def :cimi/sla-violation
   (su/only-keys :req-un [
@@ -24,4 +29,6 @@
                         :cimi.common/updated
                         :cimi.sla-violation/agreement_id
                         :cimi.sla-violation/guarantee
-                        :cimi.sla-violation/datetime]))
+                        :cimi.sla-violation/datetime
+                        :cimi.sla-violation/constraint
+                        :cimi.sla-violation/values]))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/sla_violation_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/sla_violation_lifecycle_test.clj
@@ -66,6 +66,9 @@
                                         :agreement_id   {:href "agreement/agreement-id-01"}
                                         :guarantee      "gt01"
                                         :datetime       timestamp
+                                        :constraint     "var1 < 100 and var2 > 100"
+                                        :values         { :var1 200
+                                                        :var2 "0" }
                                     }
 
                    resp-test (-> session-admin

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/sla_violation_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/sla_violation_test.cljc
@@ -23,6 +23,9 @@
                                 :agreement_id   {:href "agreement/agreement-id"}
                                 :guarantee      "gt01"
                                 :datetime       timestamp
+                                :constraint     "var1 < 100 and var2 > 100"
+                                :values         { :var1 200
+                                                  :var2 "0" }
                                 }]
     (is (s/valid? :cimi/sla-violation sla-violation-resource))
     (is (not (s/valid? :cimi/sla-violation (assoc sla-violation-resource :bad-field "bla bla bla"))))))


### PR DESCRIPTION
Include the term constraint violated and the values that generated the violation. An sla-violation is now like:

    {
        "id": "v-id",
        "agreement_id": "a-id",
        "datetime": "2018-05-15T14:15:00Z",
        "guarantee": "gt-name",
        "constraint": "var1 < 100 and var2 > 100",
        "values": { "var1": 101, "var2": 100}
    }