### PR TITLE
Agent upc

### DIFF
--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agent.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agent.cljc
@@ -15,7 +15,7 @@
 ;     "connected": boolean,
 ;     "isLeader": boolean,
 ;     "backup_ip": string,
-;     "childrenIPs": string (List)
+;;;;     "childrenIPs": string (List)
 ;   }
 
 
@@ -28,7 +28,7 @@
 (s/def :cimi.agent/connected boolean?)
 (s/def :cimi.agent/isLeader boolean?)
 (s/def :cimi.agent/backup_ip string?)
-(s/def :cimi.agent/childrenIPs string?)
+;(s/def :cimi.agent/childrenIPs string?)
 
 
 (s/def :cimi/agent
@@ -41,6 +41,6 @@
                               :cimi.agent/connected
                               :cimi.agent/isLeader
                               :cimi.agent/backup_ip
-                              :cimi.agent/childrenIPs
+;                              :cimi.agent/childrenIPs
                                ]
                        }))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agent.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agent.cljc
@@ -15,7 +15,7 @@
 ;     "connected": boolean,
 ;     "isLeader": boolean,
 ;     "backup_ip": string,
-;;;;     "childrenIPs": string (List)
+;     "childrenIPs": string (List)
 ;   }
 
 
@@ -28,19 +28,17 @@
 (s/def :cimi.agent/connected boolean?)
 (s/def :cimi.agent/isLeader boolean?)
 (s/def :cimi.agent/backup_ip string?)
-;(s/def :cimi.agent/childrenIPs string?)
+(s/def :cimi.agent/childrenIPs (s/coll-of string?))
 
 
 (s/def :cimi/agent
-  (su/only-keys-maps c/common-attrs
-                     {:req-un[:cimi.agent/device_id
-                              :cimi.agent/device_ip
-                              :cimi.agent/leader_id
-                              :cimi.agent/leader_ip
-                              :cimi.agent/authenticated
-                              :cimi.agent/connected
-                              :cimi.agent/isLeader
-                              :cimi.agent/backup_ip
-;                              :cimi.agent/childrenIPs
-                               ]
-                       }))
+       (su/only-keys-maps c/common-attrs
+                          {:req-un [:cimi.agent/device_id
+                                     :cimi.agent/device_ip
+                                     :cimi.agent/authenticated
+                                     :cimi.agent/connected
+                                     :cimi.agent/isLeader]
+                           :opt-un [:cimi.agent/leader_id
+                                     :cimi.agent/leader_ip
+                                     :cimi.agent/backup_ip
+                                     :cimi.agent/childrenIPs]}))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
@@ -73,7 +73,7 @@
                                  :connected         true
                                  :isLeader          false
                                  :backup_ip         "0.0.0.0"
-                                 :childrenIPs       "[]"
+;                                 :childrenIPs       "[]"
                                  }
           resp-test             (-> session-admin
                                   (request base-uri

--- a/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
@@ -73,7 +73,7 @@
                                  :connected         true
                                  :isLeader          false
                                  :backup_ip         "0.0.0.0"
-;                                 :childrenIPs       "[]"
+                                 :childrenIPs       ["127.0.0.1"]
                                  }
           resp-test             (-> session-admin
                                   (request base-uri

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
@@ -34,7 +34,7 @@
                           :connected          true
                           :isLeader           false
                           :backup_ip          "0.0.0.0"
-                          :childrenIPs        "[]"
+;                          :childrenIPs        "[]"
                           }
          ]
     (is (s/valid? :cimi/agent agent-resource))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
@@ -34,7 +34,7 @@
                           :connected          true
                           :isLeader           false
                           :backup_ip          "0.0.0.0"
-;                          :childrenIPs        "[]"
+                          :childrenIPs        ["127.0.0.1"]
                           }
          ]
     (is (s/valid? :cimi/agent agent-resource))


### PR DESCRIPTION
Agent resource modified:
+ childernIPs changed to list instead of string
+ "leader_ip", "leader_id", and "backup_ip" are now optional