### PR TITLE
Make details.expiration an optional field

### DIFF
--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
@@ -65,9 +65,9 @@
                                                       :cimi.agreement/provider
                                                       :cimi.agreement/client
                                                       :cimi.agreement/creation
-                                                      :cimi.agreement/expiration
                                                       :cimi.agreement/guarantees]
-                                             :opt-un [:cimi.agreement/id]))
+                                             :opt-un [:cimi.agreement/expiration
+                                                      :cimi.agreement/id]))
 
 ; --
 


### PR DESCRIPTION
This applies to SLA agreements and templates