### PR TITLE
Make stopTime in serviceContainerMetric optional

### DIFF
--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/service_container_metric.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/service_container_metric.cljc
@@ -26,5 +26,5 @@
                          ::cimi-common/updated
                          :cimi.service-container-metric/device_id
                          :cimi.service-container-metric/container_id
-                         :cimi.service-container-metric/start_time
-                         :cimi.service-container-metric/stop_time]))
+                         :cimi.service-container-metric/start_time]
+                :opt-un [:cimi.service-container-metric/stop_time]))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/service_container_metric_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/service_container_metric_test.cljc
@@ -23,7 +23,7 @@
                                 :device_id {:href "device/d-id"}
                                 :container_id "this-is-a-container-id"
 								:start_time  "2019-08-25T10:00:00.0Z"
-								:stop_time  "2019-08-26T10:00:00.0Z"
                                 }]
     (is (s/valid? :cimi/service-container-metric resource))
+    (is (s/valid? :cimi/service-container-metric (assoc resource :stop_time "2019-08-26T10:00:00.0Z")))
     (is (not (s/valid? :cimi/service-container-metric (assoc resource :bad-field "bla bla bla"))))))


### PR DESCRIPTION
The field stopTime in ServiceContainerMetric must be optional: this resource must be created as soon as a container is started, so it can have a undefined value for stopTime.