### PR TITLE
Modify structure of agreement to allow complex guarantees

### DIFF
--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
@@ -46,6 +46,8 @@
 ;       "guarantees": [
 ;           "name": string
 ;           "constraint": string
+;           "scope": string
+;           "schedule" string
 ;       ]
 ;   }
 ; }
@@ -75,9 +77,13 @@
 
 ; DETAILS/GUARANTEE
 (s/def :cimi.agreement/constraint string?)
+(s/def :cimi.agreement/scope string?)
+(s/def :cimi.agreement/schedule string?)
 
 (s/def :cimi.agreement/guarantee (su/only-keys :req-un [::cimi-common/name
-                                                        :cimi.agreement/constraint]))
+                                                        :cimi.agreement/constraint]
+                                               :opt-un [:cimi.agreement/scope
+                                                        :cimi.agreement/schedule]))
 
 (s/def :cimi.agreement/guarantees (s/coll-of :cimi.agreement/guarantee :kind vector? :distinct true))
 

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
@@ -1,6 +1,7 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.agreement
   (:require
     [clojure.spec.alpha :as s]
+    [com.sixsq.slipstream.ssclj.resources.spec.sla-assessment :as sla-assessment]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
     [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
@@ -12,6 +13,19 @@
 ;   "assessment": {
 ;       "first_execution": dateTime
 ;       "last_execution": dateTime
+;       "guarantees": {
+;           <gt-name>: {
+;             "first_execution": dateTime
+;             "last_execution": dateTime
+;             "last_values": {
+;                "<var-name>": {
+;                    "key" string
+;                    "value" string
+;                    "datetime" timestamp
+;                }
+;             }
+;           }
+;       }
 ;   }
 ;   "details": {
 ;       "id": string    ; optional
@@ -104,5 +118,5 @@
                          :cimi.agreement/details]
                 :opt-un [::cimi-common/name
                          ::cimi-common/properties
-                         :cimi.agreement/assessment
+                         :cimi.sla-assessment/assessment
                          ::cimi-common/operations]))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
@@ -21,6 +21,14 @@
 ;       "client": { id: string, name: string}
 ;       "creation": dateTime,
 ;       "expiration": dateTime,
+;       "variables": [
+;          "name": string,
+;          "metric": string,
+;          "aggregation": {
+;             type: AVERAGE,
+;             size: int
+;          }
+;       ],
 ;       "guarantees": [
 ;           "name": string
 ;           "constraint": string
@@ -31,15 +39,16 @@
 (s/def :cimi.agreement/state #{"started" "stopped" "terminated"})
 
 ; ASSESSMENT
-(s/def :cimi.agreement/first_execution ::cimi-core/timestamp)
-(s/def :cimi.agreement/last_execution ::cimi-core/timestamp)
-
-(s/def :cimi.agreement/assessment (su/only-keys :req-un [:cimi.agreement/first_execution
-                                                         :cimi.agreement/last_execution]))
+; namespace in sla-assessment
 
 ; DETAILS
 (s/def :cimi.agreement/id string?)
-(s/def :cimi.agreement/type #{"agreement" "template"})
+
+; type is used in details.type and details.variables.aggregation.type
+; The following is better than just using a string without needing to create
+; a new namespace for one of the two usages.
+(s/def :cimi.agreement/type #{"agreement" "template" "average"})
+;(s/def :cimi.agreement/type string?)
 
 (s/def :cimi.agreement/party (su/only-keys :req-un [:cimi.agreement/id ; this could a common/resourceURI in the near future
                                                     ::cimi-common/name]))
@@ -58,6 +67,19 @@
 
 (s/def :cimi.agreement/guarantees (s/coll-of :cimi.agreement/guarantee :kind vector? :distinct true))
 
+; DETAILS/VARIABLES
+(s/def :cimi.agreement/metric string?)
+(s/def :cimi.agreement/window nat-int?)
+(s/def :cimi.agreement/aggregation (su/only-keys :req-un [
+                                            :cimi.agreement/type 
+                                            :cimi.agreement/window]))
+
+(s/def :cimi.agreement/variable (su/only-keys :req-un [::cimi-common/name]
+                                              :opt-un [:cimi.agreement/metric
+                                                       :cimi.agreement/aggregation]))
+
+(s/def :cimi.agreement/variables (s/coll-of :cimi.agreement/variable :kind vector? :distinct true))
+
 ; --
 
 (s/def :cimi.agreement/details (su/only-keys :req-un [:cimi.agreement/type
@@ -67,6 +89,7 @@
                                                       :cimi.agreement/creation
                                                       :cimi.agreement/guarantees]
                                              :opt-un [:cimi.agreement/expiration
+                                                      :cimi.agreement/variables
                                                       :cimi.agreement/id]))
 
 ; --

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/sla_assessment.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/sla_assessment.cljc
@@ -1,0 +1,53 @@
+; Namespace sla-assessment corresponds to agreement.assessment
+
+(ns com.sixsq.slipstream.ssclj.resources.spec.sla-assessment
+  (:require
+    [clojure.spec.alpha :as s]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
+
+;   "assessment": {
+;       "first_execution": dateTime
+;       "last_execution": dateTime
+;       "guarantees": {
+;           <gt-name>: {
+;             "first_execution": dateTime
+;             "last_execution": dateTime
+;             "last_values": {
+;                "<var-name>": {
+;                    "key" string
+;                    "value" string
+;                    "datetime" timestamp
+;                }
+;             }
+;           }
+;       }
+
+
+(s/def :cimi.sla-assessment/first_execution ::cimi-core/timestamp)
+(s/def :cimi.sla-assessment/last_execution ::cimi-core/timestamp)
+(s/def :cimi.sla-assessment/key string?)
+(s/def :cimi.sla-assessment/value any?)
+(s/def :cimi.sla-assessment/datetime ::cimi-core/timestamp)
+
+
+(s/def :cimi.sla-assessment/metricvalue (su/only-keys
+        :req-un [:cimi.sla-assessment/key
+                :cimi.sla-assessment/value
+                :cimi.sla-assessment/datetime]))
+
+(s/def :cimi.sla-assessment/last_values (su/constrained-map keyword? :cimi.sla-assessment/metricvalue))
+
+(s/def :cimi.sla-assessment/guarantee (su/only-keys
+        :req-un [:cimi.sla-assessment/first_execution
+                :cimi.sla-assessment/last_execution]
+        :opt-un [:cimi.sla-assessment/last_values]))
+
+(s/def :cimi.sla-assessment/guarantees (su/constrained-map keyword? :cimi.sla-assessment/guarantee))
+
+(s/def :cimi.sla-assessment/assessment (su/only-keys
+        :req-un [:cimi.sla-assessment/first_execution
+                :cimi.sla-assessment/last_execution]
+        :opt-un [:cimi.sla-assessment/guarantees]))
+

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
@@ -62,6 +62,12 @@
                                                 :name   "gt1"
                                                 :constraint "m > 0"
                                             }
+                                            {
+                                                :name   "gt2"
+                                                :constraint "m2 > 0"
+                                                :scope  "Operation1"
+                                                :schedule   "hourly"
+                                            }
                                     ]
                                 }
                                 }

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
@@ -22,6 +22,18 @@
                                    :rules [{:principal "ADMIN"
                                             :type      "ROLE"
                                             :right     "MODIFY"}]}
+        aggregation {
+            :type   "average"
+            :window 600
+        }
+        variable    {
+            :name   "m"
+            :metric "_m"
+            :aggregation aggregation
+        }
+        variables   [
+            variable
+        ]
         agreement-resource     {:id            (str resource-url "/agreement-resource")
                                 :resourceURI    resource-uri
                                 :created        timestamp
@@ -35,6 +47,16 @@
                                     :client     client
                                     :creation   timestamp
                                     :expiration timestamp
+                                    :variables [
+                                        {
+                                            :name "m"
+                                            :metric "_m"
+                                            :aggregation {
+                                                :type "average"
+                                                :window 600
+                                            }
+                                        }
+                                    ]
                                     :guarantees [
                                             { 
                                                 :name   "gt1"
@@ -43,5 +65,6 @@
                                     ]
                                 }
                                 }]
+
     (is (s/valid? :cimi/agreement agreement-resource))
     (is (not (s/valid? :cimi/agreement (assoc agreement-resource :bad-field "bla bla bla"))))))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agreement_test.cljc
@@ -64,7 +64,25 @@
                                             }
                                     ]
                                 }
-                                }]
+                                }
+        initial-assessment      {:first_execution timestamp
+                                :last_execution timestamp}
+        last        {:m0        {:key "m0"
+                                :value 50.0
+                                :datetime timestamp}
+                    :m1         {:key "m1"
+                                :value 51
+                                :datetime timestamp}}
+        guarantees {:gt0        {:first_execution   timestamp
+                                :last_execution     timestamp
+                                :last_values        last}
+        }
+        assessment  {           :first_execution    timestamp
+                                :last_execution     timestamp
+                                :guarantees         guarantees
+        }]
 
     (is (s/valid? :cimi/agreement agreement-resource))
+    (is (s/valid? :cimi/agreement (assoc agreement-resource :assessment initial-assessment)))
+    (is (s/valid? :cimi/agreement (assoc agreement-resource :assessment assessment)))
     (is (not (s/valid? :cimi/agreement (assoc agreement-resource :bad-field "bla bla bla"))))))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/sla_assessment_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/sla_assessment_test.cljc
@@ -1,0 +1,30 @@
+(ns com.sixsq.slipstream.ssclj.resources.spec.sla-assessment-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [are deftest is]]
+            [com.sixsq.slipstream.ssclj.resources.common.schema :as schema]
+            [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
+            [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+
+(deftest check-assessment-resource-schema
+  (let [
+        first_execution         "2019-07-08T10:00:00.01Z"
+        last_execution          "2019-07-08T14:57:00.01Z"
+        last        {:m0        {:key "m0"
+                                :value 50.0
+                                :datetime first_execution}
+                    :m1         {:key "m1"
+                                :value 51
+                                :datetime last_execution}}
+        guarantees {:gt0        {:first_execution   first_execution
+                                :last_execution     last_execution
+                                :last_values        last}
+        }
+        initial-assessment      {:first_execution   first_execution
+                                :last_execution     last_execution
+        }]
+
+; Not working - testing directly in agreement-test
+;    (is (s/valid? :cimi/sla-assessment/assessment initial-assessment))
+;    (is (s/valid? :cimi/sla-assessment/assessment (assoc initial-assessment :guarantees guarantees)))
+;    (is (not (s/valid? :cimi/sla-assessment/assessment (assoc initial-assessment :bad-field "bla bla bla"))))
+))


### PR DESCRIPTION
This PR adds:
- a definition for variables used in guarantee constraints, allowing to specify additional information about the metrics used (like aggregation)
- store more assessment information
- add scope and schedule fields to guarantees, which add a way to add more information about the resource being evaluated and period of evaluation.