### PR TITLE
change code so that it works with older cimi

### DIFF
--- a/_demo/session-jwt-cmds.sh
+++ b/_demo/session-jwt-cmds.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -xe
+
+# check that the server is responding
+curl -k https://localhost/api/cloud-entry-point 
+
+# check number of session templates available; should only be 'internal'
+curl -k https://localhost/api/session-template 
+
+# add the jwt session template
+curl -k -H 'slipstream-authn-info: internal ADMIN' -H content-type:application/json -d @session-template-jwt.json https://localhost/api/session-template 
+
+# verify that it is there and available anonymously
+curl -k https://localhost/api/session-template/jwt
+
+# login with a token
+#
+# NOTE: This will fail with a 400 unless you provide a valid JWT!
+#       Add your token to session-jwt-login.json.
+#
+curl -k -XPOST -H content-type:application/json -d @session-jwt-login.json https://localhost/api/session

--- a/_demo/session-jwt-login.json
+++ b/_demo/session-jwt-login.json
@@ -1,0 +1,6 @@
+{
+    "sessionTemplate": {
+        "href": "session-template/jwt",
+        "token": "some-valid-token"
+    }
+}

--- a/_demo/session-template-jwt.json
+++ b/_demo/session-template-jwt.json
@@ -1,0 +1,26 @@
+{
+    "method": "jwt",
+    "instance": "jwt",
+    "name": "JWT Authentication",
+    "description": "External Authentication with JWT",
+    "token": "provide-valid-authentication-token",
+    "acl": {
+        "owner": {
+            "principal": "ADMIN",
+            "type": "ROLE"
+        },
+        "rules": [
+            {"principal": "ADMIN",
+             "type": "ROLE",
+             "right": "ALL"},
+         
+            {"principal": "ANON",
+             "type": "ROLE",
+             "right": "VIEW"},
+            
+            {"principal": "USER",
+             "type": "ROLE",
+             "right": "VIEW"}
+        ]
+    }
+}

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_template_jwt.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_template_jwt.clj
@@ -6,10 +6,8 @@
   (:require
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
-    [com.sixsq.slipstream.ssclj.resources.resource-metadata :as md]
     [com.sixsq.slipstream.ssclj.resources.session-template :as p]
-    [com.sixsq.slipstream.ssclj.resources.spec.session-template-jwt :as session-tpl]
-    [com.sixsq.slipstream.ssclj.util.metadata :as gen-md]))
+    [com.sixsq.slipstream.ssclj.resources.spec.session-template-jwt :as session-tpl]))
 
 
 (def ^:const authn-method "jwt")
@@ -42,8 +40,7 @@
 (defn initialize
   []
   (p/register authn-method desc)
-  (std-crud/initialize p/resource-url ::session-tpl/schema)
-  (md/register (gen-md/generate-metadata ::ns ::p/ns ::session-tpl/schema)))
+  (std-crud/initialize p/resource-url ::session-tpl/schema))
 
 
 ;;

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_jwt.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_jwt.cljc
@@ -1,32 +1,12 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.session-template-jwt
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.common-namespaces :as common-ns]
     [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.session-template :as ps]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [spec-tools.core :as st]))
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
-(s/def ::token
-  (-> (st/spec ::cimi-core/nonblank-string)
-      (assoc :name "token"
-             :json-schema/name "token"
-             :json-schema/namespace common-ns/slipstream-namespace
-             :json-schema/uri common-ns/slipstream-uri
-             :json-schema/type "string"
-             :json-schema/providerMandatory true
-             :json-schema/consumerMandatory true
-             :json-schema/mutable true
-             :json-schema/consumerWritable true
-
-             :json-schema/displayName "token"
-             :json-schema/description "JSON Web Token"
-             :json-schema/help "JSON Web Token"
-             :json-schema/group "body"
-             :json-schema/order 20
-             :json-schema/hidden false
-             :json-schema/sensitive true)))
+(s/def ::token ::cimi-core/nonblank-string)
 
 ;; all parameters must be specified in both the template and the create resource
 (def session-template-keys-spec

--- a/server/test/com/sixsq/slipstream/ssclj/resources/session_template_jwt_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/session_template_jwt_lifecycle_test.clj
@@ -1,23 +1,3 @@
-(ns com.sixsq.slipstream.ssclj.resources.session-template-jwt-lifecycle-test
-  (:require
-    [clojure.test :refer :all]
-    [com.sixsq.slipstream.ssclj.app.params :as p]
-    [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
-    [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
-    [com.sixsq.slipstream.ssclj.resources.session-template :as st]
-    [com.sixsq.slipstream.ssclj.resources.session-template-jwt :as jwt]
-    [com.sixsq.slipstream.ssclj.util.metadata-test-utils :as mdtu]))
-
-
-(use-fixtures :each ltu/with-test-server-fixture)
-
-
-(def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
-
-
-
-(deftest check-metadata
-  (mdtu/check-metadata-exists (str st/resource-url "-" jwt/resource-url)))
-
+(ns com.sixsq.slipstream.ssclj.resources.session-template-jwt-lifecycle-test)
 
 ;; FIXME: There should be a lifecycle test!


### PR DESCRIPTION
Fixes the code for the JWT sessions so that it works with the older CIMI being used in the _demo area. The commands that work (as far as they can be tested without a running authentication server) can be found in the `session-jwt-cmds.sh` file. 
