### PR TITLE
strip whitespace from aclib response

### DIFF
--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt.clj
@@ -74,7 +74,7 @@
                 (let [cookies {(sutils/cookie-name (:id session)) cookie}]
                   [{:cookies cookies} session]))
               (jwt-utils/throw-inactive-user iss))
-            (jwt-utils/throw-invalid-jwt (str "token validation error '" validation-response "'"))))
+            (jwt-utils/throw-invalid-jwt (format "token validation error '%s'" validation-response))))
         (jwt-utils/throw-no-issuer))
       (jwt-utils/throw-invalid-jwt "cannot parse JWT"))
     (jwt-utils/throw-no-token)))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
@@ -5,10 +5,10 @@
     [buddy.sign.jws :as jws]
     [clojure.data.json :as json]
     [clojure.edn :as edn]
+    [clojure.string :as str]
     [com.sixsq.slipstream.ssclj.util.log :as logu]
     [environ.core :as env]
-    [manifold.stream :as stream]
-    [clojure.string :as str]))
+    [manifold.stream :as stream]))
 
 
 (def aclib-host (env/env :mf2c-aclib-host "aclib"))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
@@ -7,7 +7,8 @@
     [clojure.edn :as edn]
     [com.sixsq.slipstream.ssclj.util.log :as logu]
     [environ.core :as env]
-    [manifold.stream :as stream]))
+    [manifold.stream :as stream]
+    [clojure.string :as str]))
 
 
 (def aclib-host (env/env :mf2c-aclib-host "aclib"))
@@ -44,7 +45,7 @@
               (case take-response
                 :timeout (logu/log-and-throw 500 (format "take from %s:%s timed out after %s ms" aclib-host aclib-port timeout))
                 :error (logu/log-and-throw 500 (format "take from %s:%s failed" aclib-host aclib-port))
-                (codecs/bytes->str take-response)))
+                (str/trim (codecs/bytes->str take-response))))
             (if (= put-response :timeout)
               (logu/log-and-throw 500 (format "put to %s:%s timed out after %s ms" aclib-host aclib-port timeout))
               (logu/log-and-throw 500 (format "failed to send message to %s:%s" aclib-host aclib-port)))))))


### PR DESCRIPTION
Strip whitespace from aclib responses so that newline characters (and other whitespace) don't interfere with checking the value of the response.