### PR TITLE
fix use of incompatible versions

### DIFF
--- a/_demo/docker-compose-es.yml
+++ b/_demo/docker-compose-es.yml
@@ -31,7 +31,7 @@ services:
     ports:
      - "5601:5601"
   rc:
-    image: sixsq/ring-container:3.53-SNAPSHOT
+    image: sixsq/ring-container:3.67
     expose:
      - "5000"
     volumes:
@@ -52,7 +52,7 @@ services:
      - ringcontainer:/opt/slipstream/ring-container
      - ringcontainerexample:/opt/slipstream/ring-example
   rc:
-    image: sixsq/ring-container:3.53-SNAPSHOT
+    image: sixsq/ring-container:3.67
     expose:
      - "5000"
     volumes:

--- a/_demo/docker-compose.yml
+++ b/_demo/docker-compose.yml
@@ -35,7 +35,7 @@ services:
      - ringcontainer:/opt/slipstream/ring-container
      - ringcontainerexample:/opt/slipstream/ring-example
   rc:
-    image: sixsq/ring-container:3.53-SNAPSHOT
+    image: sixsq/ring-container:3.67
     expose:
      - "5000"
     volumes:

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- must match the version of the parent -->
-    <slipstream.version>3.53-SNAPSHOT</slipstream.version>
+    <slipstream.version>3.67</slipstream.version>
   </properties>
 
   <modules>

--- a/server/src/com/sixsq/slipstream/db/dataclay/loader.clj
+++ b/server/src/com/sixsq/slipstream/db/dataclay/loader.clj
@@ -2,10 +2,10 @@
   (:refer-clojure :exclude [load])
   (:require
     [clojure.core.async :refer [<!!]]
+    [clojure.tools.logging :as log]
     [com.sixsq.slipstream.db.dataclay.binding :as dataclay]
     [environ.core :as env]
-    [kvlt.chan :as kvlt]
-    [clojure.tools.logging :as log]))
+    [kvlt.chan :as kvlt]))
 
 
 (defn send-command

--- a/server/src/com/sixsq/slipstream/db/dataclay/loader_direct.clj
+++ b/server/src/com/sixsq/slipstream/db/dataclay/loader_direct.clj
@@ -1,10 +1,10 @@
 (ns com.sixsq.slipstream.db.dataclay.loader-direct
   (:refer-clojure :exclude [load])
   (:require
-    [com.sixsq.dataclay.handler :as proxy]
-    [com.sixsq.slipstream.db.dataclay.binding :as dataclay]
+    [clojure.edn :as edn]
     [clojure.tools.logging :as log]
-    [clojure.edn :as edn]))
+    [com.sixsq.dataclay.handler :as proxy]
+    [com.sixsq.slipstream.db.dataclay.binding :as dataclay]))
 
 
 (defn send-fn

--- a/server/src/com/sixsq/slipstream/ssclj/resources/agent.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/agent.clj
@@ -1,15 +1,15 @@
 (ns
   com.sixsq.slipstream.ssclj.resources.agent
   (:require
+    [clj-time.core :as time]
     [com.sixsq.slipstream.auth.acl :as a]
     [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
+    [com.sixsq.slipstream.ssclj.resources.event :as event]
     [com.sixsq.slipstream.ssclj.resources.spec.agent]
     [com.sixsq.slipstream.util.response :as r]
-    [clj-time.core :as time]
-    [com.sixsq.slipstream.ssclj.resources.event :as event]
     [superstring.core :as str]))
 
 (def ^:const resource-name "Agent")

--- a/server/src/com/sixsq/slipstream/ssclj/resources/device.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/device.clj
@@ -1,15 +1,15 @@
 (ns
   com.sixsq.slipstream.ssclj.resources.device
   (:require
+    [clj-time.core :as time]
     [com.sixsq.slipstream.auth.acl :as a]
     [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
+    [com.sixsq.slipstream.ssclj.resources.event :as event]
     [com.sixsq.slipstream.ssclj.resources.spec.device]
     [com.sixsq.slipstream.util.response :as r]
-    [clj-time.core :as time]
-    [com.sixsq.slipstream.ssclj.resources.event :as event]
     [superstring.core :as str]))
 
 (def ^:const resource-name "Device")

--- a/server/src/com/sixsq/slipstream/ssclj/resources/device_dynamic.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/device_dynamic.clj
@@ -1,14 +1,14 @@
 (ns
   com.sixsq.slipstream.ssclj.resources.device-dynamic
   (:require
+    [clj-time.core :as time]
     [com.sixsq.slipstream.auth.acl :as a]
     [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
-    [com.sixsq.slipstream.ssclj.resources.spec.device-dynamic]
     [com.sixsq.slipstream.ssclj.resources.event :as event]
-    [clj-time.core :as time]
+    [com.sixsq.slipstream.ssclj.resources.spec.device-dynamic]
     [superstring.core :as str]))
 
 (def ^:const resource-name "DeviceDynamic")

--- a/server/src/com/sixsq/slipstream/ssclj/resources/service.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/service.clj
@@ -1,11 +1,11 @@
 (ns
   com.sixsq.slipstream.ssclj.resources.service
   (:require
-    [clojure.pprint :as pp]
-    [com.sixsq.slipstream.auth.acl :as a]
     [clj-http.client :as http]
     [clojure.data.json :as json]
+    [clojure.pprint :as pp]
     [clojure.walk :refer [keywordize-keys]]
+    [com.sixsq.slipstream.auth.acl :as a]
     [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt.clj
@@ -7,6 +7,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.session :as p]
+    [com.sixsq.slipstream.ssclj.resources.session-jwt.aclib :as aclib]
     [com.sixsq.slipstream.ssclj.resources.session-jwt.utils :as jwt-utils]
     [com.sixsq.slipstream.ssclj.resources.session-template-api-key :as tpl]
     [com.sixsq.slipstream.ssclj.resources.session.utils :as sutils]
@@ -56,7 +57,7 @@
   (if token
     (if-let [{:keys [iss]} (jwt-utils/extract-claims token)]
       (if iss
-        (let [validation-response (jwt-utils/validate-jwt token)]
+        (let [validation-response (aclib/validate-jwt token)]
           (if (= "OK" validation-response)
             (if-let [matched-user (jwt-utils/match-user iss)]
               (let [session-info {:href href, :username matched-user}

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/aclib.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/aclib.clj
@@ -1,0 +1,73 @@
+(ns com.sixsq.slipstream.ssclj.resources.session-jwt.aclib
+  (:refer-clojure :exclude [send])
+  (:require
+    [aleph.tcp :as tcp]
+    [buddy.core.codecs :as codecs]
+    [clojure.data.json :as json]
+    [clojure.edn :as edn]
+    [clojure.string :as str]
+    [com.sixsq.slipstream.ssclj.util.log :as logu]
+    [environ.core :as env]
+    [manifold.stream :as stream]))
+
+
+(def host (env/env :mf2c-aclib-host "aclib"))
+
+
+(def port (edn/read-string (env/env :mf2c-aclib-port "46080")))
+
+
+;; This exceptionally long timeout is needed because the first request to
+;; the ACLIB server can take 10-15s because of server initialization.
+(def timeout 20000)
+
+
+;; wrapped to allow for testing
+(defn put!
+  [client msg timeout timeout-val]
+  @(stream/try-put! client msg timeout timeout-val))
+
+
+;; wrapped to allow for testing
+(defn take!
+  [client error-val timeout timeout-val]
+  @(stream/try-take! client error-val timeout timeout-val))
+
+
+(defn tcp-client
+  "Creates a TCP client used to connect to the ACLIB server."
+  [host port]
+  (try
+    @(tcp/client {:host host, :port port})
+    (catch Exception e
+      (logu/log-and-throw 500 (format "error when connecting to %s:%s: %s" host port (str e))))))
+
+
+(defn send
+  "Sends the wrapped JWT token to the ACLIB server. Returns nil on success,
+   throws an exception otherwise."
+  [client wrapped-jwt]
+  (let [resp (put! client wrapped-jwt timeout :timeout)]
+    (case resp
+      :timeout (logu/log-and-throw 500 (format "put to %s:%s timed out after %s ms" host port timeout))
+      false (logu/log-and-throw 500 (format "failed to send message to %s:%s" host port))
+      nil)))
+
+
+(defn receive
+  "Waits for a response from the ACLIB server and provides the response as a
+   trimmed string. Throws exceptions on failures."
+  [client]
+  (let [take-response (take! client :error timeout :timeout)]
+    (case take-response
+      :timeout (logu/log-and-throw 500 (format "take from %s:%s timed out after %s ms" host port timeout))
+      :error (logu/log-and-throw 500 (format "take from %s:%s failed" host port))
+      (str/trim (codecs/bytes->str take-response)))))
+
+
+(defn validate-jwt
+  [token]
+  (with-open [client (tcp-client host port)]
+    (let [wrapped-jwt (str (json/write-str {:typ "jwt", :token token}) "\n")]
+      (send client wrapped-jwt)
+      (receive client))))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/session_jwt/utils.clj
@@ -1,76 +1,39 @@
 (ns com.sixsq.slipstream.ssclj.resources.session-jwt.utils
   (:require
-    [aleph.tcp :as tcp]
     [buddy.core.codecs :as codecs]
     [buddy.sign.jws :as jws]
     [clojure.data.json :as json]
-    [clojure.edn :as edn]
-    [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.log :as logu]
-    [environ.core :as env]
-    [manifold.stream :as stream]))
+    [com.sixsq.slipstream.ssclj.util.log :as logu]))
 
 
-(def aclib-host (env/env :mf2c-aclib-host "aclib"))
-
-
-(def aclib-port (edn/read-string (env/env :mf2c-aclib-port "46080")))
-
-
-(def timeout 20000)
-
-
-;; WARNING: Private functions are used. May break with buddy version updates!
 (defn extract-claims
   [base64-token]
   (try
     (some-> base64-token
-            (#'jws/split-jws-message)
+            (#'jws/split-jws-message)                       ;; private function, may break with buddy updates!
             second
-            (#'jws/decode-payload)
+            (#'jws/decode-payload)                          ;; private function, may break with buddy updates!
             codecs/bytes->str
             (json/read-str :key-fn keyword))
     (catch Exception _
       nil)))
 
 
-(defn validate-jwt
-  [token]
-  (try
-    (with-open [client @(tcp/client {:host aclib-host, :port aclib-port})]
-      (let [msg (str (json/write-str {:typ "jwt", :token token}) "\n")]
-        (let [put-response @(stream/try-put! client msg timeout :timeout)]
-          (if (true? put-response)
-            (let [take-response @(stream/try-take! client :error timeout :timeout)]
-              (case take-response
-                :timeout (logu/log-and-throw 500 (format "take from %s:%s timed out after %s ms" aclib-host aclib-port timeout))
-                :error (logu/log-and-throw 500 (format "take from %s:%s failed" aclib-host aclib-port))
-                (str/trim (codecs/bytes->str take-response))))
-            (if (= put-response :timeout)
-              (logu/log-and-throw 500 (format "put to %s:%s timed out after %s ms" aclib-host aclib-port timeout))
-              (logu/log-and-throw 500 (format "failed to send message to %s:%s" aclib-host aclib-port)))))))
-    (catch Exception e
-      (if (ex-data e)
-        (throw e)
-        (logu/log-and-throw 500 (format "error when connecting to %s:%s: %s" aclib-host aclib-port (str e)))))))
-
-
 ;; FIXME: If user matching is needed, the method/contents of the user resource must be defined.
 (def match-user identity)
 
-;; general exceptions
 
 (defn throw-no-token []
   (logu/log-and-throw-400 "unable to retrieve JWT authentication token"))
 
+
 (defn throw-no-issuer []
   (logu/log-and-throw-400 (str "JWT token is missing issuer (iss) attribute")))
 
-(defn throw-invalid-access-code [msg]
-  (logu/log-and-throw-400 (str "error when processing JWT authentication token: " msg)))
 
 (defn throw-invalid-jwt [msg]
   (logu/log-and-throw-400 (str "invalid JWT authentication token: " msg)))
+
 
 (defn throw-inactive-user [username]
   (logu/log-and-throw-400 (str "account is inactive (" username ")")))

--- a/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
+++ b/server/src/com/sixsq/slipstream/ssclj/resources/spec/agreement.cljc
@@ -1,9 +1,9 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.agreement
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.sla-assessment :as sla-assessment]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
     [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.sla-assessment :as sla-assessment]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ; {

--- a/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/agent_lifecycle_test.clj
@@ -4,11 +4,11 @@
     [clojure.test :refer :all]
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
+    [com.sixsq.slipstream.ssclj.resources.agent :as agent]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.example-resource.utils :as utils]
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
-    [com.sixsq.slipstream.ssclj.resources.agent :as agent]
     [peridot.core :refer :all]))
 
 (use-fixtures :each ltu/with-test-server-fixture)

--- a/server/test/com/sixsq/slipstream/ssclj/resources/service_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/service_lifecycle_test.clj
@@ -3,9 +3,9 @@
     :license   "http://www.apache.org/licenses/LICENSE-2.0"}
   com.sixsq.slipstream.ssclj.resources.service-lifecycle-test
   (:require
+    [clj-http.client :as http]
     [clojure.data.json :as json]
     [clojure.test :refer :all]
-    [clj-http.client :as http]
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]

--- a/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt/aclib_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt/aclib_test.clj
@@ -1,0 +1,70 @@
+(ns
+  ^{:copyright "Copyright 2019, SixSq Sàrl"
+    :license   "http://www.apache.org/licenses/LICENSE-2.0"}
+  com.sixsq.slipstream.ssclj.resources.session-jwt.aclib-test
+  (:require
+    [aleph.tcp :as tcp]
+    [clojure.test :refer :all]
+    [com.sixsq.slipstream.ssclj.resources.session-jwt.aclib :as t])
+  (:import
+    (clojure.lang ExceptionInfo)
+    (java.io Closeable)))
+
+
+(def no-op-client
+  (proxy
+    [Closeable] []
+    (close [] nil)))
+
+
+(defn check-thrown-exception
+  [token test-name pattern]
+  (try
+    (t/validate-jwt token)
+    (is false test-name)
+    (catch Exception e
+      (is (instance? ExceptionInfo e))
+      (let [{:keys [status body]} (ex-data e)
+            {body-status :status body-message :message} body]
+        (is (= 500 status))
+        (is (= 500 body-status))
+        (is (re-matches pattern body-message))))))
+
+
+(deftest check-validate-jwt
+
+  (let [msg   "connection error"
+        token "placeholder-token"]
+
+    (with-redefs [tcp/client (fn [opts] (throw (ex-info msg {:message msg})))]
+      (is (thrown-with-msg? ExceptionInfo (re-pattern msg) (t/validate-jwt token))))
+
+    (with-redefs [tcp/client (fn [opts] (throw (Exception. msg)))]
+      (check-thrown-exception token "client connection" (re-pattern (str "^error when connecting.*" msg ".*$"))))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] :timeout)]
+      (check-thrown-exception token "put timeout" #"^put to.*timed out.*$"))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] false)]
+      (check-thrown-exception token "put general failure" #"^failed to send message.*$"))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] false)]
+      (check-thrown-exception token "put general failure" #"^failed to send message.*$"))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] true)
+                  t/take!    (fn [_ _ _ _] :timeout)]
+      (check-thrown-exception token "take timeout" #"^take.*timed out.*$"))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] true)
+                  t/take!    (fn [_ _ _ _] :error)]
+      (check-thrown-exception token "take error" #"^take.*failed.*$"))
+
+    (with-redefs [tcp/client (constantly (atom no-op-client))
+                  t/put!     (fn [_ _ _ _] true)
+                  t/take!    (fn [_ _ _ _] (byte-array (map byte "OK\n")))]
+      (is (= "OK" (t/validate-jwt token))))))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt/utils_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt/utils_test.clj
@@ -4,11 +4,11 @@
   com.sixsq.slipstream.ssclj.resources.session-jwt.utils-test
   (:require
     [clojure.test :refer [are deftest is]]
-    [com.sixsq.slipstream.ssclj.resources.session-jwt.utils :as t]
-    [com.sixsq.slipstream.auth.utils.sign :as sign]))
+    [com.sixsq.slipstream.auth.utils.sign :as sign]
+    [com.sixsq.slipstream.ssclj.resources.session-jwt.utils :as t]))
 
 
-(deftest check-jwt-parsing
+(deftest check-extract-claims
 
   (is (nil? (t/extract-claims nil)))
   (is (nil? (t/extract-claims "invalid")))

--- a/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/session_jwt_lifecycle_test.clj
@@ -1,25 +1,24 @@
 (ns com.sixsq.slipstream.ssclj.resources.session-jwt-lifecycle-test
   (:require
+    [aleph.tcp :as tcp]
+    [buddy.core.codecs :as codecs]
     [clojure.data.json :as json]
     [clojure.string :as str]
     [clojure.test :refer [deftest is use-fixtures]]
-    [com.sixsq.slipstream.auth.external :as ex]
     [com.sixsq.slipstream.auth.utils.sign :as sign]
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
     [com.sixsq.slipstream.ssclj.resources.session :as session]
+    [com.sixsq.slipstream.ssclj.resources.session-jwt.aclib :as aclib]
+    [com.sixsq.slipstream.ssclj.resources.session-jwt.utils :as jwt-utils]
     [com.sixsq.slipstream.ssclj.resources.session-template :as ct]
     [com.sixsq.slipstream.ssclj.resources.session-template :as st]
     [com.sixsq.slipstream.ssclj.resources.session-template-jwt :as jwt]
-    [peridot.core :refer :all]
-    [com.sixsq.slipstream.ssclj.resources.session-jwt.utils :as jwt-utils]
-    [aleph.tcp :as tcp]
-    [manifold.stream :as stream]
-    [clojure.tools.logging :as log]
     [manifold.deferred :as d]
-    [buddy.core.codecs :as codecs]))
+    [manifold.stream :as stream]
+    [peridot.core :refer :all]))
 
 
 (use-fixtures :each ltu/with-test-server-fixture)
@@ -104,8 +103,8 @@
 
 (deftest sanity-check-test-aclib-server
   (let [timeout 1000]
-    (with-open [server (start-server jwt-utils/aclib-port)
-                client @(tcp/client {:host jwt-utils/aclib-host, :port jwt-utils/aclib-port})]
+    (with-open [server (start-server aclib/port)
+                client @(tcp/client {:host aclib/host, :port aclib/port})]
 
       (let [token  (sign/sign-claims {:test-result "OK"})
             msg    (str (json/write-str {:typ "jwt", :token token}) "\n")
@@ -124,7 +123,7 @@
 
 (deftest lifecycle
 
-  (with-open [server (start-server jwt-utils/aclib-port)]
+  (with-open [server (start-server aclib/port)]
 
     (let [app           (ltu/ring-app)
           session-json  (content-type (session app) "application/json")

--- a/server/test/com/sixsq/slipstream/ssclj/resources/session_template_jwt_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/session_template_jwt_lifecycle_test.clj
@@ -1,3 +1,132 @@
-(ns com.sixsq.slipstream.ssclj.resources.session-template-jwt-lifecycle-test)
+(ns com.sixsq.slipstream.ssclj.resources.session-template-jwt-lifecycle-test
+  (:require
+    [clojure.data.json :as json]
+    [clojure.test :refer [deftest is use-fixtures]]
+    [com.sixsq.slipstream.ssclj.app.params :as p]
+    [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
+    [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
+    [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
+    [com.sixsq.slipstream.ssclj.resources.session-template :as st]
+    [com.sixsq.slipstream.ssclj.resources.session-template-jwt :as jwt]
+    [peridot.core :refer :all]))
 
-;; FIXME: There should be a lifecycle test!
+
+(use-fixtures :each ltu/with-test-server-fixture)
+
+
+(def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
+
+
+(def session-template-base-uri (str p/service-context (u/de-camelcase st/resource-name)))
+
+
+(def instance "test-instance")
+
+
+(def session-template-jwt {:method      jwt/authn-method
+                           :instance    instance
+                           :name        "JWT Authentication"
+                           :description "External Authentication with JWT"
+                           :token       "provide-valid-authentication-token"
+                           :acl         st/resource-acl})
+
+
+(deftest lifecycle
+
+  (let [app           (ltu/ring-app)
+        session-json  (content-type (session app) "application/json")
+        session-anon  (header session-json authn-info-header "unknown ANON")
+        session-user  (header session-json authn-info-header "user USER ANON")
+        session-admin (header session-json authn-info-header "root ADMIN USER ANON")]
+
+    ;; only admin should be able to create a session template instance
+    (doseq [session [session-user session-anon]]
+      (-> session
+          (request session-template-base-uri
+                   :request-method :post
+                   :body (json/write-str session-template-jwt))
+          (ltu/body->edn)
+          (ltu/is-status 403)))
+
+    ;; anonymous query should succeed, only "internal" template should be visible
+    (-> session-anon
+        (request base-uri)
+        (ltu/body->edn)
+        (ltu/is-status 200)
+        (ltu/is-count 1))
+
+    ;; create the JWT session template
+    (let [href         (-> session-admin
+                           (request session-template-base-uri
+                                    :request-method :post
+                                    :body (json/write-str session-template-jwt))
+                           (ltu/body->edn)
+                           (ltu/is-status 201)
+                           (ltu/location))
+
+          template-url (str p/service-context href)]
+
+      ;; verify that the session template exists and can be seen by anon
+      (-> session-anon
+          (request template-url)
+          (ltu/body->edn)
+          (ltu/is-status 200)
+          (ltu/is-operation-absent "delete")
+          (ltu/is-operation-absent "edit"))
+
+      ;; anonymous query should succeed with "internal" and new template visible
+      (-> session-anon
+          (request base-uri)
+          (ltu/body->edn)
+          (ltu/is-status 200)
+          (ltu/is-count 2))
+
+      ;; check rights for admin
+      (-> session-admin
+          (request template-url)
+          (ltu/body->edn)
+          (ltu/is-status 200)
+          (ltu/is-operation-present "delete")
+          (ltu/is-operation-present "edit"))
+
+      ;; only admin should be able to delete a session template
+      (doseq [session [session-user session-anon]]
+        (-> session
+            (request template-url
+                     :request-method :delete)
+            (ltu/body->edn)
+            (ltu/is-status 403)))
+
+      ;; try editing the session template
+      (let [new-name "updated name attribute"]
+
+        ;; change the name of the template
+        (-> session-admin
+            (request template-url
+                     :request-method :put
+                     :body (json/write-str {:name new-name}))
+            (ltu/body->edn)
+            (ltu/is-status 200))
+
+        ;; verify that the name has changed
+        (let [{updated-name :name} (-> session-admin
+                                       (request template-url)
+                                       (ltu/body->edn)
+                                       (ltu/is-status 200)
+                                       :response
+                                       :body)]
+          (is (= updated-name new-name))))
+
+      ;; admin should be able to delete session template
+      (-> session-admin
+          (request template-url
+                   :request-method :delete)
+          (ltu/body->edn)
+          (ltu/is-status 200))
+
+      ;; verify that the session template has disappeared
+      (-> session-admin
+          (request template-url)
+          (ltu/body->edn)
+          (ltu/is-status 404)))))
+

--- a/server/test/com/sixsq/slipstream/ssclj/resources/sla_template_lifecycle_test.clj
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/sla_template_lifecycle_test.clj
@@ -7,12 +7,12 @@
     [clojure.test :refer :all]
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
-    [com.sixsq.slipstream.ssclj.resources.sla-template :as sla-template]
-    [com.sixsq.slipstream.ssclj.resources.sla-template :as callback]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.example-resource.utils :as utils]
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
+    [com.sixsq.slipstream.ssclj.resources.sla-template :as sla-template]
+    [com.sixsq.slipstream.ssclj.resources.sla-template :as callback]
     [peridot.core :refer :all]))
 
 (use-fixtures :each ltu/with-test-server-fixture)

--- a/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
+++ b/server/test/com/sixsq/slipstream/ssclj/resources/spec/agent_test.cljc
@@ -1,9 +1,9 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.agent-test
   (:require [clojure.spec.alpha :as s]
             [clojure.test :refer [are deftest is]]
+            [com.sixsq.slipstream.ssclj.resources.agent :as t]
             [com.sixsq.slipstream.ssclj.resources.common.schema :as schema]
             [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
-            [com.sixsq.slipstream.ssclj.resources.agent :as t]
             [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
 
 (deftest check-agent-resource-schema


### PR DESCRIPTION
Ensure all parts of the code use SlipStream v3.67 (including the deployed containers). Refactor code for testability and add detailed tests for interactions with aclib server.
